### PR TITLE
feat: Import libsumo instead of traci when available...

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,14 @@ requires-python = ">=3.13"
 dependencies = [
     "jsmin>=3.0.1",
     "keyboard>=0.13.5",
+    "libsumo>=1.27.0",
     "nats-py>=2.14.0",
     "numpy>=2.4.6",
     "pandas>=3.0.3",
     "python-dateutil>=2.9.0.post0",
     "pytz>=2026.2",
     "six>=1.17.0",
+    "traci>=1.27.0",
     "transitions>=0.9.3",
     "tzdata>=2026.2",
 ]

--- a/services/simengine/src/simengine_integrated.py
+++ b/services/simengine/src/simengine_integrated.py
@@ -8,28 +8,25 @@ This module operates Sumo simulator and applies controller to it
 # All Rights Reserved
 # rt random
 import os
+import platform
 import sys
 import time
 from typing import Any
 
+# Prefer libsumo when available because it avoids TraCI's socket
+# communication overhead and is significantly faster for simulation-heavy
+# workloads. The code aliases the selected backend as `traci` because both
+# libraries expose nearly identical APIs.
+if platform.system() == "Windows":
+    import traci
+elif platform.system() in ("Linux", "Darwin"):
+    import libsumo as traci
+else:
+    raise SystemError("Unknown operating system: ", platform.system())
+
+
 from confread_ms import GlobalConf
 from timer import Timer
-
-# This will need:
-# export PYTHONPATH=$PYTHONPATH:/usr/share/sumo/tools
-
-# Alternatively:
-# we need to import python modules from the $SUMO_HOME/tools directory
-if "SUMO_HOME" in os.environ:
-    SUMO_TOOLS = os.path.join(os.environ["SUMO_HOME"], "tools")
-    sys.path.append(SUMO_TOOLS)
-    import traci
-    # import libsumo as traci
-else:
-    sys.exit("please declare environment variable 'SUMO_HOME'")
-
-# from sumolib import checkBinary  # noqa
-
 
 # Note these are not in use at sig-group
 DEFAULT_ROUTE_FILE = "testmodel/cross.rou.xml"


### PR DESCRIPTION
libsumo uses direct C++ bindings instead of socket communication like TraCI. This leads to much faster execution that is preferrable when running Open Controller with a lot of calls to different SUMO APIs. libsumo also now supports running in GUI mode on Linux and Mac and can thus entirely replace TraCI on those platforms.

libsumo and TraCI should also be installed from a Python package manager rather than imported from SUMO_HOME/tools since the SUMO tools installation can be incomplete.