### PR TITLE
Fix missing dependency

### DIFF
--- a/tests/integration.Dockerfile
+++ b/tests/integration.Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install necessary system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	ca-certificates software-properties-common
+	ca-certificates software-properties-common libatomic1
 
 # Install uv using the installation script
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/


### PR DESCRIPTION
Not having libatomic1 explicitly installed in the Dockerfile sometimes caused libsumo import to crash. This was a weird bug but it seems that installing it manually fixes the issue.