### PR TITLE
Transit detectors

### DIFF
--- a/services/control_engine/src/detectors/area_detector.py
+++ b/services/control_engine/src/detectors/area_detector.py
@@ -31,3 +31,7 @@ class AreaDetector(ABC):
     def average_time_loss(self) -> float:
         """Average time loss (s) experienced by vehicles in the area."""
         ...
+
+
+class TransitAreaDetector(AreaDetector):
+    """Area detector for detecting transit vehicles."""

--- a/services/control_engine/src/detectors/point_detector.py
+++ b/services/control_engine/src/detectors/point_detector.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+TRANSIT_VEHICLE_TYPES: list[str] = ["bus", "tram"]
+
 
 class PointDetector(ABC):
     """Detector interface for interacting with a point detector.
@@ -25,3 +27,7 @@ class PointDetector(ABC):
     def detection_duration(self) -> float:
         """Duration of the current detection in seconds."""
         ...
+
+
+class TransitPointDetector(PointDetector):
+    """Point detector for detecting transit vehicles."""

--- a/services/control_engine/src/detectors/sumo_e1_detector.py
+++ b/services/control_engine/src/detectors/sumo_e1_detector.py
@@ -1,48 +1,62 @@
+from abc import ABC, abstractmethod
+
 import libsumo
 
-from .point_detector import PointDetector
+from .point_detector import TRANSIT_VEHICLE_TYPES, PointDetector, TransitPointDetector
 
 
-class E1PointDetector(PointDetector):
-    """Point detector implementation using SUMO's E1 detector."""
+class BaseE1Detector(PointDetector, ABC):
+    """Shared implementation layer for all SUMO E1-based detectors."""
 
     def __init__(self, detector_id: str) -> None:
         super().__init__()
-
         self._id = detector_id
-
-        self._current_time: float = 0  # Current simulation time in seconds
-        self._occupied: bool = False  # Start the detector as not occupied
-        self._detection_start: float = -1  # Time of the last occupation start
+        self._current_time: float = 0
+        self._occupied: bool = False
+        self._detection_start: float = -1
 
     def tick(self) -> None:
-        """Update the detector's internal status."""
-        # Update the detectors internal clock
+        """Update the detector."""
         self._current_time = libsumo.simulation.getTime()
 
-        currently_occupied = (
-            libsumo.inductionloop.getLastStepVehicleNumber(self._id) > 0
-        )
+        # Defer the specific occupancy rule to the subclass
+        currently_occupied = self._check_occupancy()
 
-        # If detector was not occupied previously but now is, detection starts.
         if not self._occupied and currently_occupied:
             self._occupied = True
             self._detection_start = self._current_time
-
-        # If detector was occupied but is no longer, detection ends.
         elif self._occupied and not currently_occupied:
             self._occupied = False
             self._detection_start = -1
 
     @property
     def is_occupied(self) -> bool:
-        """True if detector currently detects a vehicle."""
+        """True if detector currently has a vehicle detected."""
         return self._occupied
 
     @property
     def detection_duration(self) -> float:
         """Duration of the current detection in seconds."""
         if not self._occupied:
-            return 0
-
+            return 0.0
         return self._current_time - self._detection_start
+
+    @abstractmethod
+    def _check_occupancy(self) -> bool: ...
+
+
+class E1PointDetector(BaseE1Detector):
+    """Point detector implementation using SUMO's E1 detector."""
+
+    def _check_occupancy(self) -> bool:
+        return libsumo.inductionloop.getLastStepVehicleNumber(self._id) > 0
+
+
+class E1TransitPointDetector(BaseE1Detector, TransitPointDetector):
+    """Transit point detector using SUMO's E1 detector."""
+
+    def _check_occupancy(self) -> bool:
+        vehicle_data = libsumo.inductionloop.getVehicleData(self._id)
+        return any(
+            vType in TRANSIT_VEHICLE_TYPES for (_, _, _, _, vType) in vehicle_data
+        )

--- a/services/control_engine/src/detectors/sumo_e2_detector.py
+++ b/services/control_engine/src/detectors/sumo_e2_detector.py
@@ -1,41 +1,82 @@
+from abc import ABC, abstractmethod
+
 import libsumo
 
-from .area_detector import AreaDetector
+from .area_detector import AreaDetector, TransitAreaDetector
+from .point_detector import TRANSIT_VEHICLE_TYPES
 
 
-class E2AreaDetector(AreaDetector):
-    """AreaDetector implementation using SUMO's E2 detector."""
+class BaseE2AreaDetector(AreaDetector, ABC):
+    """Shared implementation layer for all SUMO E2-based area detectors."""
 
     def __init__(self, detector_id: str) -> None:
         super().__init__()
-
         self._id = detector_id
-
         self._vehicle_count: float = 0.0
         self._average_speed: float = 0.0
         self._average_time_loss: float = 0.0
 
     def tick(self) -> None:
-        """Update detections from simulation."""
-        self._vehicle_count = float(libsumo.lanearea.getLastStepVehicleNumber(self._id))
+        """Update the detectors internal state."""
+        raw_count, raw_speed, raw_loss = self._fetch_metrics()
 
-        speed = float(libsumo.lanearea.getLastStepMeanSpeed(self._id))
-        self._average_speed = max(0.0, speed)
-
-        loss = float(libsumo.lanearea.getLastIntervalMeanTimeLoss(self._id))
-        self._average_time_loss = max(0.0, loss)
+        self._vehicle_count = float(raw_count)
+        self._average_speed = max(0.0, float(raw_speed))
+        self._average_time_loss = max(0.0, float(raw_loss))
 
     @property
     def vehicle_count(self) -> float:
-        """Total number of vehicles currently in detection area."""
+        """Total number or vehicles currently in the area."""
         return self._vehicle_count
 
     @property
     def average_speed(self) -> float:
-        """Average speed (m/s) of vehicles in the detection area."""
+        """Average speed (m/s) of a vehicle currently in the area."""
         return self._average_speed
 
     @property
     def average_time_loss(self) -> float:
-        """Average time loss (s) of vehicles in the detection area."""
+        """Average time loss (s) experienced by vehicles in the area."""
         return self._average_time_loss
+
+    @abstractmethod
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        """Get readings from the detector.
+
+        Returns:
+            Vehicle count, average speed, and average time loss.
+
+        """
+        ...
+
+
+class E2AreaDetector(BaseE2AreaDetector):
+    """AreaDetector implementation using SUMO's E2 detector."""
+
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        count = libsumo.lanearea.getLastStepVehicleNumber(self._id)
+        speed = libsumo.lanearea.getLastStepMeanSpeed(self._id)
+        loss = libsumo.lanearea.getLastIntervalMeanTimeLoss(self._id)
+        return count, speed, loss
+
+
+class E2TransitAreaDetector(BaseE2AreaDetector, TransitAreaDetector):
+    """AreaDetector implementation using SUMO's E2 detector for transit only."""
+
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        vehicle_ids = libsumo.lanearea.getLastStepVehicleIDs(self._id)
+        transit_ids = [
+            v
+            for v in vehicle_ids
+            if libsumo.vehicle.getTypeID(v) in TRANSIT_VEHICLE_TYPES
+        ]
+
+        count = len(transit_ids)
+        if count > 0:
+            speed = sum(libsumo.vehicle.getSpeed(v) for v in transit_ids) / count
+            loss = sum(libsumo.vehicle.getTimeLoss(v) for v in transit_ids) / count
+        else:
+            # If no transit vehicles are detected, values signal no readings.
+            speed, loss = -1.0, -1.0
+
+        return count, speed, loss

--- a/services/control_engine/src/detectors/sumo_e3_detector.py
+++ b/services/control_engine/src/detectors/sumo_e3_detector.py
@@ -1,45 +1,82 @@
+from abc import ABC, abstractmethod
+
 import libsumo
 
-from .area_detector import AreaDetector
+from .area_detector import AreaDetector, TransitAreaDetector
+from .point_detector import TRANSIT_VEHICLE_TYPES
 
 
-class E3AreaDetector(AreaDetector):
-    """AreaDetector implementation using SUMO's E3 detector."""
+class BaseE3AreaDetector(AreaDetector, ABC):
+    """Shared implementation layer for all SUMO E3-based area detectors."""
 
     def __init__(self, detector_id: str) -> None:
         super().__init__()
-
         self._id = detector_id
-
         self._vehicle_count: float = 0.0
         self._average_speed: float = 0.0
         self._average_time_loss: float = 0.0
 
     def tick(self) -> None:
-        """Update detections from simulation."""
-        self._vehicle_count = float(
-            libsumo.multientryexit.getLastStepVehicleNumber(self._id),
-        )
+        """Update the detectors internal state."""
+        raw_count, raw_speed, raw_loss = self._fetch_metrics()
 
-        raw_speed = float(libsumo.multientryexit.getLastStepMeanSpeed(self._id))
-        self._average_speed = max(0.0, raw_speed)
-
-        raw_time_loss = float(
-            libsumo.multientryexit.getLastIntervalMeanTimeLoss(self._id),
-        )
-        self._average_time_loss = max(0.0, raw_time_loss)
+        self._vehicle_count = float(raw_count)
+        self._average_speed = max(0.0, float(raw_speed))
+        self._average_time_loss = max(0.0, float(raw_loss))
 
     @property
     def vehicle_count(self) -> float:
-        """Total number of vehicles currently in detection area."""
+        """Total number or vehicles currently in the area."""
         return self._vehicle_count
 
     @property
     def average_speed(self) -> float:
-        """Average speed (m/s) of vehicles in the detection area."""
+        """Average speed (m/s) of a vehicle currently in the area."""
         return self._average_speed
 
     @property
     def average_time_loss(self) -> float:
-        """Average time loss (s) of vehicles in the detection area."""
+        """Average time loss (s) experienced by vehicles in the area."""
         return self._average_time_loss
+
+    @abstractmethod
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        """Get readings from the detector.
+
+        Returns:
+            Vehicle count, average speed, and average time loss.
+
+        """
+        ...
+
+
+class E3AreaDetector(BaseE3AreaDetector):
+    """AreaDetector implementation using SUMO's E3 detector."""
+
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        count = libsumo.multientryexit.getLastStepVehicleNumber(self._id)
+        speed = libsumo.multientryexit.getLastStepMeanSpeed(self._id)
+        loss = libsumo.multientryexit.getLastIntervalMeanTimeLoss(self._id)
+        return count, speed, loss
+
+
+class E3TransitAreaDetector(BaseE3AreaDetector, TransitAreaDetector):
+    """AreaDetector implementation using SUMO's E3 detector for transit only."""
+
+    def _fetch_metrics(self) -> tuple[float, float, float]:
+        vehicle_ids = libsumo.multientryexit.getLastStepVehicleIDs(self._id)
+        transit_ids = [
+            v
+            for v in vehicle_ids
+            if libsumo.vehicle.getTypeID(v) in TRANSIT_VEHICLE_TYPES
+        ]
+
+        count = len(transit_ids)
+        if count > 0:
+            speed = sum(libsumo.vehicle.getSpeed(v) for v in transit_ids) / count
+            loss = sum(libsumo.vehicle.getTimeLoss(v) for v in transit_ids) / count
+        else:
+            # If no transit vehicles are detected, values signal no readings.
+            speed, loss = -1.0, -1.0
+
+        return count, speed, loss


### PR DESCRIPTION
Transit vehicles can be detected separately with transit detectors. In simulation you can create both normal detector and a transit detector for the same detector ID. In the real world you would request data from traffic indicators to both kinds of detectors.

This transit detector class makes it possible to decide, where you want to collect transit detections, and where generic detections are sufficient. This can be useful for controllers with transit priorities.

You can always check the type of a detector with:

```python
from services.control_engine.src.detectors.point_detector import TransitPointDetector, PointDetector
from services.control_engine.src.detectors.sumo_e1_detector import E1TransitPointDetector

detector = E1TransitPointDetector("detector id")

if isinstance(detector, TransitPointDetector):
    print("This is a transit detector!")

if isinstance(detector, PointDetector):
    print("This is also a point detector!")
```