### PR TITLE
fix: switch to relative import paths and modules

### DIFF
--- a/services/control_engine/src/extender.py
+++ b/services/control_engine/src/extender.py
@@ -10,7 +10,6 @@ it easier to implement external control schemes
 # All Rights Reserved
 #
 
-from signal_group import SignalGroup
 import keyboard, time
 
 

--- a/services/control_engine/src/signal_group_controller.py
+++ b/services/control_engine/src/signal_group_controller.py
@@ -21,16 +21,15 @@ Design principles:
 
 #from transitions.extensions import GraphMachine as Machine
 from transitions import Machine as Machine
-from confread import GlobalConf # For testing
+from .confread import GlobalConf # For testing
 import pandas as pd
 
-from signal_group import SignalGroup
-from signal_group import value_is_number # Should be in utils unit or something
-from timer import Timer
-from stats import StatLogger
-from detector import Detector, ExtDetector, GrpDetector, e3Detector
-from extender import Extender, StaticExtender, e3Extender
-from lane import Lane
+from .signal_group import SignalGroup
+from .signal_group import value_is_number # Should be in utils unit or something
+from .timer import Timer
+from .detector import Detector, ExtDetector, GrpDetector, e3Detector
+from .extender import Extender, StaticExtender, e3Extender
+from .lane import Lane
 import sys
 import json
 

--- a/services/simengine/src/simengine_integrated.py
+++ b/services/simengine/src/simengine_integrated.py
@@ -19,6 +19,7 @@ from typing import Any
 # workloads. The code aliases the selected backend as `traci` because both
 # libraries expose nearly identical APIs.
 if platform.system() == "Windows":
+    # import libsumo as traci
     import traci
 elif platform.system() in ("Linux", "Darwin"):
     import libsumo as traci
@@ -36,26 +37,12 @@ SUMO_BIN_NAME = "sumo"
 SUMO_BIN_NAME_GRAPH = "sumo-gui"
 
 # Imprtinc components from control_engine
-# FIXME:We should not use paths, insteead different sercives should
-# Be properly modularized and imported as modules
-engine_path = "services/control_engine/src"  # Standard installation
-sys.path.append(engine_path)
-from signal_group_controller import PhaseRingController
-
+from services.control_engine.src.signal_group_controller import PhaseRingController
 
 # We run the sumo model based on conf dictionery given as parameter
 def run_sumo():
     """Run sumo with given configuration"""
     unit_cnf = GlobalConf()  # Open Controller configuration.
-
-    # Imprtinc components from control_engine
-    # FIXME:We should not use paths, insteead different sercives should
-    # Be properly modularized and imported as modules
-    if "control_engine_path" in unit_cnf.cnf:
-        engine_path = unit_cnf.cnf["control_engine_path"]
-    else:
-        engine_path = "services/control_engine/src"  # Standard installation
-    sys.path.append(engine_path)
 
     controllers_dict = {}
 


### PR DESCRIPTION
Switch to relative import paths and modules.
Improving the reusability of the code (integrated version only)
Open controller must be used with the -m option python -m services.simengine.src.simengine_integrated --conf-file ...