### PR TITLE
Make WebSUMO work for models without geo-coordinates

### DIFF
--- a/services/simengine/doc/websumo.md
+++ b/services/simengine/doc/websumo.md
@@ -37,11 +37,16 @@ merged into one document. The viewer needs nothing on its own disk.
 - A NATS server. Address resolution, in order: `--nats-server` /
   `--nats-port` command line params, the conf file's `nats` section,
   `localhost:4222`.
-- **A geo-referenced net.** WebSUMO renders in WGS84; the net must have
-  a real `projParameter` in its `<location>` element. A synthetic net
-  (`projParameter="!"`) disables the interface at the first publish. A
-  synthetic net can be geo-referenced by borrowing the `<location>`
-  line of a real model.
+- A geo-referenced net is **not** required. WebSUMO renders in WGS84,
+  so a net with a real `projParameter` in its `<location>` element is
+  shown where it lives on the map. A net without one
+  (`projParameter="!"`) still works: the interface anchors it at
+  lon/lat 0,0 ("null island", open ocean) by injecting a synthetic
+  spherical web mercator projection into the served net file and
+  converting the published positions with the same projection. The
+  viewer works normally there - the model just has no real map
+  background to toggle on. Revisit if WebSUMO gets a native no-geo
+  mode (see the issue tracker).
 - For real-time viewing, use `"timer_mode": "real"` in the conf's timer
   section. In `fixed` mode the engine runs at full CPU speed and the
   viewer shows a fast-forward simulation — the interface adds no timing
@@ -103,5 +108,6 @@ New websumo commits: `docker compose build --no-cache websumo`.
   the container entrypoints break on a CRLF checkout. Docker Desktop's
   restart button never picks up a rebuilt image — use
   `docker compose up` from a terminal.
-- **Viewer loads but Load fails with a geo-projection error**: the net
-  is not geo-referenced, see Requirements.
+- **Viewer loads but the model is nowhere to be found**: a net without
+  a geo-reference is anchored at lon/lat 0,0, see Requirements - use
+  the viewer's fit-to-network, not the map location you expected.

--- a/services/simengine/src/websumo_interface.py
+++ b/services/simengine/src/websumo_interface.py
@@ -44,6 +44,8 @@ can go and both engines can call NATS directly on their own loop.
 # Copyright 2026 by Conveqs Oy and Kari Koskinen
 # All Rights Reserved
 
+from __future__ import annotations
+
 import asyncio
 import gzip
 import io
@@ -52,6 +54,8 @@ import math
 import os
 import threading
 import xml.etree.ElementTree as ET
+from concurrent.futures import Future
+from typing import Any, Callable
 
 import libsumo
 from nats.aio.client import Client as NATS
@@ -80,11 +84,15 @@ SYNTHETIC_PROJ = ("+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 "
 SYNTHETIC_PROJECTION = ('projParameter="' + SYNTHETIC_PROJ + '"').encode()
 EARTH_RADIUS_M = 6378137.0
 
+# An x/y meters to lon/lat degrees conversion function
+GeoConverter = Callable[[float, float], "tuple[float, float]"]
+
 
 class WebsumoInterface:
     """Publishes the simulation state of one scenario to NATS"""
 
-    def __init__(self, sumocfg_file, nats_conf=None, enabled=True):
+    def __init__(self, sumocfg_file: str, nats_conf: dict | str | None = None,
+                 enabled: bool = True) -> None:
         """Connects to NATS and starts serving the scenario files
 
         sumocfg_file: path of the sumocfg the engine is running, used
@@ -121,7 +129,7 @@ class WebsumoInterface:
             net_file = net_file_from_sumocfg(sumocfg_file)
             with open(net_file, "rb") as f:
                 net_bytes = f.read()
-            net_bytes, self._geo_offset = geo_reference_net(net_bytes)
+            net_bytes, self._geo_offset = _geo_reference_net(net_bytes)
             if self._geo_offset is None:
                 self._convert_geo = libsumo.simulation.convertGeo
             else:
@@ -155,7 +163,7 @@ class WebsumoInterface:
                   self._nats_url, ":", e)
             self._stop_thread()
 
-    async def _connect_and_serve(self):
+    async def _connect_and_serve(self) -> None:
         """Connects to the nats server and answers the file requests"""
         self._nats = NATS()
         await self._nats.connect(
@@ -185,7 +193,7 @@ class WebsumoInterface:
         await self._nats.subscribe(self._subject_prefix + ".cmd.select",
                                    cb=on_select)
 
-    def publish_state(self):
+    def publish_state(self) -> None:
         """Reads the current state from sumo and publishes it
 
         Called from the engine's own update tick, right after
@@ -224,13 +232,13 @@ class WebsumoInterface:
             self._publish(self._subject_prefix + ".log",
                           json.dumps(log_message).encode())
 
-    def publish_end(self):
+    def publish_end(self) -> None:
         """Tells the viewer that the simulation has ended"""
         if not self.connected:
             return
         self._publish(self._subject_prefix + ".end", b"{}")
 
-    def close(self):
+    def close(self) -> None:
         """Flushes pending messages and stops the background thread"""
         if self.connected:
             self.connected = False
@@ -243,14 +251,14 @@ class WebsumoInterface:
         if self._thread is not None:
             self._stop_thread()
 
-    def _publish(self, subject, payload):
+    def _publish(self, subject: str, payload: bytes) -> None:
         # Fire and forget: the engine never waits for the delivery, but
         # a failed delivery (broker gone mid-run) disables the interface
         future = asyncio.run_coroutine_threadsafe(
             self._nats.publish(subject, payload), self._loop)
         future.add_done_callback(self._check_publish_result)
 
-    def _check_publish_result(self, future):
+    def _check_publish_result(self, future: Future) -> None:
         """Disables the interface when a publish fails (broker gone)"""
         try:
             error = future.exception()
@@ -261,21 +269,21 @@ class WebsumoInterface:
                   "publishing failed:", error)
             self.connected = False
 
-    def _stop_thread(self):
+    def _stop_thread(self) -> None:
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=CLOSE_TIMEOUT_SECONDS)
 
-    def _synthetic_convert(self, x, y):
+    def _synthetic_convert(self, x: float, y: float) -> tuple[float, float]:
         """convertGeo() replacement for a net without a geo-projection
 
         libsumo's convertGeo() does not fail on such a net - it silently
         returns the x/y meters unchanged, which the viewer would read as
         degrees. This converts with the synthetic projection instead.
         """
-        return synthetic_lonlat(x, y, self._geo_offset)
+        return _synthetic_lonlat(x, y, self._geo_offset)
 
 
-def get_vehicle_states(convert_geo):
+def get_vehicle_states(convert_geo: GeoConverter) -> list[list]:
     """Returns the vehicle list in the WebSUMO state format
 
     convert_geo: the x/y meters to lon/lat conversion, normally
@@ -297,7 +305,7 @@ def get_vehicle_states(convert_geo):
     return vehicles
 
 
-def get_person_states(convert_geo):
+def get_person_states(convert_geo: GeoConverter) -> list[list]:
     """Returns the pedestrian and cyclist list in the WebSUMO format
 
     convert_geo: as in get_vehicle_states()
@@ -316,7 +324,7 @@ def get_person_states(convert_geo):
     return persons
 
 
-def get_traffic_light_states():
+def get_traffic_light_states() -> dict[str, str]:
     """Returns the signal state strings of all traffic lights"""
     lights = {}
     for tls_id in libsumo.trafficlight.getIDList():
@@ -324,7 +332,7 @@ def get_traffic_light_states():
     return lights
 
 
-def get_detector_states():
+def get_detector_states() -> dict[str, bool]:
     """Returns the occupancy status of all e1 detectors"""
     detectors = {}
     for det_id in libsumo.inductionloop.getIDList():
@@ -334,7 +342,7 @@ def get_detector_states():
     return detectors
 
 
-def get_events():
+def get_events() -> list[dict]:
     """Returns the exceptional events of this step
 
     Collisions, teleports and emergency stops, as shown in the
@@ -354,7 +362,7 @@ def get_events():
     return events
 
 
-def get_inspect_state(selection):
+def get_inspect_state(selection: dict) -> dict:
     """Returns the details of the element selected in the viewer
 
     The field names follow the WebSUMO protocol. A "gone" marker is
@@ -372,7 +380,7 @@ def get_inspect_state(selection):
             "gone": True}
 
 
-def get_vehicle_details(veh_id):
+def get_vehicle_details(veh_id: str) -> dict[str, Any]:
     """Returns the inspection details of one vehicle"""
     vehicle = libsumo.vehicle
     leader = vehicle.getLeader(veh_id)
@@ -406,7 +414,7 @@ def get_vehicle_details(veh_id):
     }
 
 
-def get_traffic_light_details(tls_id):
+def get_traffic_light_details(tls_id: str) -> dict[str, Any]:
     """Returns the inspection details of one traffic light"""
     trafficlight = libsumo.trafficlight
     program = trafficlight.getProgram(tls_id)
@@ -427,21 +435,22 @@ def get_traffic_light_details(tls_id):
     }
 
 
-def geo_reference_net(net_bytes):
+def _geo_reference_net(
+        net_bytes: bytes) -> tuple[bytes, tuple[float, float] | None]:
     """Injects the synthetic projection if the net has none
 
     Returns (net_bytes, net_offset): the net file bytes to serve and,
     when the synthetic projection was injected, the netOffset needed by
-    synthetic_lonlat(). net_offset is None for a net that already has a
+    _synthetic_lonlat(). net_offset is None for a net that already has a
     real geo-projection (the bytes are returned unchanged).
     """
     if NO_PROJECTION not in net_bytes:
         return net_bytes, None
     return (net_bytes.replace(NO_PROJECTION, SYNTHETIC_PROJECTION, 1),
-            net_offset_from_net(net_bytes))
+            _net_offset_from_net(net_bytes))
 
 
-def net_offset_from_net(net_bytes):
+def _net_offset_from_net(net_bytes: bytes) -> tuple[float, float]:
     """Returns the netOffset pair of the net file's <location> element"""
     for _, element in ET.iterparse(io.BytesIO(net_bytes)):
         if element.tag == "location":
@@ -451,7 +460,9 @@ def net_offset_from_net(net_bytes):
     return 0.0, 0.0
 
 
-def synthetic_lonlat(x, y, net_offset=(0.0, 0.0)):
+def _synthetic_lonlat(x: float, y: float,
+                      net_offset: tuple[float, float] = (0.0, 0.0),
+                      ) -> tuple[float, float]:
     """Converts net x/y meters to lon/lat in the synthetic projection
 
     The exact inverse of SYNTHETIC_PROJ (spherical web mercator), with
@@ -467,17 +478,17 @@ def synthetic_lonlat(x, y, net_offset=(0.0, 0.0)):
     return lon, lat
 
 
-def scenario_from_sumocfg(sumocfg_file):
+def scenario_from_sumocfg(sumocfg_file: str) -> str:
     """Returns the scenario name: the sumocfg file name without suffix"""
     return os.path.splitext(os.path.basename(sumocfg_file))[0]
 
 
-def net_file_from_sumocfg(sumocfg_file):
+def net_file_from_sumocfg(sumocfg_file: str) -> str:
     """Returns the path of the net file the sumocfg points at"""
     return input_files_from_sumocfg(sumocfg_file, "net-file")[0]
 
 
-def merged_detectors_from_sumocfg(sumocfg_file):
+def merged_detectors_from_sumocfg(sumocfg_file: str) -> bytes | None:
     """Returns all e1 detectors of the scenario as one xml document
 
     WebSUMO renders the detector bars from a single detector file, but
@@ -501,7 +512,7 @@ def merged_detectors_from_sumocfg(sumocfg_file):
     return ET.tostring(merged)
 
 
-def input_files_from_sumocfg(sumocfg_file, tag):
+def input_files_from_sumocfg(sumocfg_file: str, tag: str) -> list[str]:
     """Returns the paths listed in one input tag of the sumocfg
 
     The paths in the sumocfg are relative to the sumocfg itself; the
@@ -518,7 +529,7 @@ def input_files_from_sumocfg(sumocfg_file, tag):
             for name in value.split(",") if name.strip()]
 
 
-def nats_conf_from_sys_conf(sys_cnf):
+def nats_conf_from_sys_conf(sys_cnf: dict) -> dict:
     """Returns the nats parameters for the interface from the conf
 
     The conf file's "nats" section, overridden by the --nats-server and
@@ -534,7 +545,7 @@ def nats_conf_from_sys_conf(sys_cnf):
     return nats_conf
 
 
-def nats_url(nats_conf):
+def nats_url(nats_conf: dict | str | None) -> str:
     """Returns the nats server url for the given conf value
 
     Accepts the conf dictionary format ({"server": ..., "port": ...},

--- a/services/simengine/src/websumo_interface.py
+++ b/services/simengine/src/websumo_interface.py
@@ -46,7 +46,9 @@ can go and both engines can call NATS directly on their own loop.
 
 import asyncio
 import gzip
+import io
 import json
+import math
 import os
 import threading
 import xml.etree.ElementTree as ET
@@ -62,6 +64,21 @@ CLOSE_TIMEOUT_SECONDS = 3
 # WebSUMO renders detector bars from these elements (both tags name the
 # same SUMO e1 detector)
 E1_DETECTOR_TAGS = ("e1Detector", "inductionLoop")
+
+# Nets without a geo-reference (projParameter="!" in the <location>
+# element) still get a working viewer: the net is anchored at lon/lat
+# 0,0 using spherical web mercator - the projection MapLibre renders
+# in, so near 0,0 the shapes stay meter-true and undistorted. The
+# served net file gets this projection injected into its header, so
+# WebSUMO's own sumolib conversion of the network geometry agrees
+# exactly with the positions published from here. 0,0 is open ocean:
+# the viewer works normally, there is just no map background to toggle
+# on. (Revisit when WebSUMO gets a native no-geo mode.)
+NO_PROJECTION = b'projParameter="!"'
+SYNTHETIC_PROJ = ("+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 "
+                  "+x_0=0 +y_0=0 +k=1 +units=m +no_defs")
+SYNTHETIC_PROJECTION = ('projParameter="' + SYNTHETIC_PROJ + '"').encode()
+EARTH_RADIUS_M = 6378137.0
 
 
 class WebsumoInterface:
@@ -103,7 +120,15 @@ class WebsumoInterface:
         try:
             net_file = net_file_from_sumocfg(sumocfg_file)
             with open(net_file, "rb") as f:
-                self._net_payload = gzip.compress(f.read())
+                net_bytes = f.read()
+            net_bytes, self._geo_offset = geo_reference_net(net_bytes)
+            if self._geo_offset is None:
+                self._convert_geo = libsumo.simulation.convertGeo
+            else:
+                print("WebSUMO: the net has no geo-projection, "
+                      "anchoring the view at lon/lat 0,0")
+                self._convert_geo = self._synthetic_convert
+            self._net_payload = gzip.compress(net_bytes)
             detectors = merged_detectors_from_sumocfg(sumocfg_file)
             if detectors is None:
                 self._detectors_payload = None
@@ -174,8 +199,8 @@ class WebsumoInterface:
             state = {
                 "v": 1,
                 "t": round(libsumo.simulation.getTime(), 1),
-                "vehicles": get_vehicle_states(),
-                "persons": get_person_states(),
+                "vehicles": get_vehicle_states(self._convert_geo),
+                "persons": get_person_states(self._convert_geo),
                 "tls": get_traffic_light_states(),
                 "detectors": get_detector_states(),
                 "_empty": libsumo.simulation.getMinExpectedNumber() == 0,
@@ -240,13 +265,26 @@ class WebsumoInterface:
         self._loop.call_soon_threadsafe(self._loop.stop)
         self._thread.join(timeout=CLOSE_TIMEOUT_SECONDS)
 
+    def _synthetic_convert(self, x, y):
+        """convertGeo() replacement for a net without a geo-projection
 
-def get_vehicle_states():
-    """Returns the vehicle list in the WebSUMO state format"""
+        libsumo's convertGeo() does not fail on such a net - it silently
+        returns the x/y meters unchanged, which the viewer would read as
+        degrees. This converts with the synthetic projection instead.
+        """
+        return synthetic_lonlat(x, y, self._geo_offset)
+
+
+def get_vehicle_states(convert_geo):
+    """Returns the vehicle list in the WebSUMO state format
+
+    convert_geo: the x/y meters to lon/lat conversion, normally
+        libsumo.simulation.convertGeo (synthetic for a no-geo net)
+    """
     vehicles = []
     for veh_id in libsumo.vehicle.getIDList():
         pos_x, pos_y = libsumo.vehicle.getPosition(veh_id)
-        lon, lat = libsumo.simulation.convertGeo(pos_x, pos_y)
+        lon, lat = convert_geo(pos_x, pos_y)
         vehicles.append([
             veh_id,
             lon,
@@ -259,12 +297,15 @@ def get_vehicle_states():
     return vehicles
 
 
-def get_person_states():
-    """Returns the pedestrian and cyclist list in the WebSUMO format"""
+def get_person_states(convert_geo):
+    """Returns the pedestrian and cyclist list in the WebSUMO format
+
+    convert_geo: as in get_vehicle_states()
+    """
     persons = []
     for person_id in libsumo.person.getIDList():
         pos_x, pos_y = libsumo.person.getPosition(person_id)
-        lon, lat = libsumo.simulation.convertGeo(pos_x, pos_y)
+        lon, lat = convert_geo(pos_x, pos_y)
         persons.append([
             person_id,
             lon,
@@ -384,6 +425,46 @@ def get_traffic_light_details(tls_id):
         "spent": round(trafficlight.getSpentDuration(tls_id), 1),
         "phases": phases,
     }
+
+
+def geo_reference_net(net_bytes):
+    """Injects the synthetic projection if the net has none
+
+    Returns (net_bytes, net_offset): the net file bytes to serve and,
+    when the synthetic projection was injected, the netOffset needed by
+    synthetic_lonlat(). net_offset is None for a net that already has a
+    real geo-projection (the bytes are returned unchanged).
+    """
+    if NO_PROJECTION not in net_bytes:
+        return net_bytes, None
+    return (net_bytes.replace(NO_PROJECTION, SYNTHETIC_PROJECTION, 1),
+            net_offset_from_net(net_bytes))
+
+
+def net_offset_from_net(net_bytes):
+    """Returns the netOffset pair of the net file's <location> element"""
+    for _, element in ET.iterparse(io.BytesIO(net_bytes)):
+        if element.tag == "location":
+            x_offset, _, y_offset = element.get(
+                "netOffset", "0.00,0.00").partition(",")
+            return float(x_offset), float(y_offset)
+    return 0.0, 0.0
+
+
+def synthetic_lonlat(x, y, net_offset=(0.0, 0.0)):
+    """Converts net x/y meters to lon/lat in the synthetic projection
+
+    The exact inverse of SYNTHETIC_PROJ (spherical web mercator), with
+    the netOffset removed first - the same conversion sumolib's
+    convertXY2LonLat() performs on the served net file, so the
+    published positions and the viewer's network geometry agree.
+    """
+    x -= net_offset[0]
+    y -= net_offset[1]
+    lon = math.degrees(x / EARTH_RADIUS_M)
+    lat = math.degrees(2.0 * math.atan(math.exp(y / EARTH_RADIUS_M))
+                       - math.pi / 2.0)
+    return lon, lat
 
 
 def scenario_from_sumocfg(sumocfg_file):

--- a/tests/test_websumo_geo_fallback.py
+++ b/tests/test_websumo_geo_fallback.py
@@ -9,9 +9,9 @@ sys.path.insert(0, "services/simengine/src")
 from websumo_interface import (  # noqa: E402
     EARTH_RADIUS_M,
     SYNTHETIC_PROJECTION,
-    geo_reference_net,
-    net_offset_from_net,
-    synthetic_lonlat,
+    _geo_reference_net,
+    _net_offset_from_net,
+    _synthetic_lonlat,
 )
 
 NO_GEO_NET = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -30,43 +30,43 @@ GEO_NET = b"""<?xml version="1.0" encoding="UTF-8"?>
 
 
 class TestGeoReferenceNet(unittest.TestCase):
-    def test_no_geo_net_gets_the_synthetic_projection(self):
-        served, offset = geo_reference_net(NO_GEO_NET)
+    def test_no_geo_net_gets_the_synthetic_projection(self) -> None:
+        served, offset = _geo_reference_net(NO_GEO_NET)
         self.assertIn(SYNTHETIC_PROJECTION, served)
         self.assertNotIn(b'projParameter="!"', served)
         self.assertEqual(offset, (10.0, 20.0))
 
-    def test_geo_net_passes_through_unchanged(self):
-        served, offset = geo_reference_net(GEO_NET)
+    def test_geo_net_passes_through_unchanged(self) -> None:
+        served, offset = _geo_reference_net(GEO_NET)
         self.assertEqual(served, GEO_NET)
         self.assertIsNone(offset)
 
-    def test_net_offset_defaults_to_zero_without_location(self):
-        self.assertEqual(net_offset_from_net(b"<net><edge/></net>"),
+    def test_net_offset_defaults_to_zero_without_location(self) -> None:
+        self.assertEqual(_net_offset_from_net(b"<net><edge/></net>"),
                          (0.0, 0.0))
 
 
 class TestSyntheticLonlat(unittest.TestCase):
-    def test_origin_is_null_island(self):
-        self.assertEqual(synthetic_lonlat(0.0, 0.0), (0.0, 0.0))
+    def test_origin_is_null_island(self) -> None:
+        self.assertEqual(_synthetic_lonlat(0.0, 0.0), (0.0, 0.0))
 
-    def test_net_offset_is_removed_first(self):
-        self.assertEqual(synthetic_lonlat(10.0, 20.0, (10.0, 20.0)),
+    def test_net_offset_is_removed_first(self) -> None:
+        self.assertEqual(_synthetic_lonlat(10.0, 20.0, (10.0, 20.0)),
                          (0.0, 0.0))
 
-    def test_matches_spherical_mercator_inverse(self):
+    def test_matches_spherical_mercator_inverse(self) -> None:
         # forward spherical web mercator of a known point, then back
         lon_deg, lat_deg = 0.01, -0.02
         x = EARTH_RADIUS_M * math.radians(lon_deg)
         y = EARTH_RADIUS_M * math.log(
             math.tan(math.pi / 4 + math.radians(lat_deg) / 2))
-        lon, lat = synthetic_lonlat(x, y)
+        lon, lat = _synthetic_lonlat(x, y)
         self.assertAlmostEqual(lon, lon_deg, places=12)
         self.assertAlmostEqual(lat, lat_deg, places=12)
 
-    def test_meter_scale_near_the_anchor(self):
+    def test_meter_scale_near_the_anchor(self) -> None:
         # one meter is about 1/111320 degrees at the equator
-        lon, lat = synthetic_lonlat(1.0, 1.0)
+        lon, lat = _synthetic_lonlat(1.0, 1.0)
         self.assertAlmostEqual(lon * 111320, 1.0, places=2)
         self.assertAlmostEqual(lat * 111320, 1.0, places=2)
 

--- a/tests/test_websumo_geo_fallback.py
+++ b/tests/test_websumo_geo_fallback.py
@@ -1,0 +1,75 @@
+import math
+import sys
+import unittest
+
+# websumo_interface lives in the engine's flat src directory and does
+# its imports accordingly, so the directory itself goes on the path
+sys.path.insert(0, "services/simengine/src")
+
+from websumo_interface import (  # noqa: E402
+    EARTH_RADIUS_M,
+    SYNTHETIC_PROJECTION,
+    geo_reference_net,
+    net_offset_from_net,
+    synthetic_lonlat,
+)
+
+NO_GEO_NET = b"""<?xml version="1.0" encoding="UTF-8"?>
+<net version="1.16">
+    <location netOffset="10.00,20.00" convBoundary="0.00,0.00,100.00,50.00" origBoundary="-10000000000.00,-10000000000.00,10000000000.00,10000000000.00" projParameter="!"/>
+    <edge id="e1"/>
+</net>
+"""
+
+GEO_NET = b"""<?xml version="1.0" encoding="UTF-8"?>
+<net version="1.16">
+    <location netOffset="-380370.77,-6669419.92" convBoundary="0.00,0.00,100.00,50.00" origBoundary="24.68,59.44,29.64,60.18" projParameter="+proj=utm +zone=35 +ellps=WGS84 +datum=WGS84 +units=m +no_defs"/>
+    <edge id="e1"/>
+</net>
+"""
+
+
+class TestGeoReferenceNet(unittest.TestCase):
+    def test_no_geo_net_gets_the_synthetic_projection(self):
+        served, offset = geo_reference_net(NO_GEO_NET)
+        self.assertIn(SYNTHETIC_PROJECTION, served)
+        self.assertNotIn(b'projParameter="!"', served)
+        self.assertEqual(offset, (10.0, 20.0))
+
+    def test_geo_net_passes_through_unchanged(self):
+        served, offset = geo_reference_net(GEO_NET)
+        self.assertEqual(served, GEO_NET)
+        self.assertIsNone(offset)
+
+    def test_net_offset_defaults_to_zero_without_location(self):
+        self.assertEqual(net_offset_from_net(b"<net><edge/></net>"),
+                         (0.0, 0.0))
+
+
+class TestSyntheticLonlat(unittest.TestCase):
+    def test_origin_is_null_island(self):
+        self.assertEqual(synthetic_lonlat(0.0, 0.0), (0.0, 0.0))
+
+    def test_net_offset_is_removed_first(self):
+        self.assertEqual(synthetic_lonlat(10.0, 20.0, (10.0, 20.0)),
+                         (0.0, 0.0))
+
+    def test_matches_spherical_mercator_inverse(self):
+        # forward spherical web mercator of a known point, then back
+        lon_deg, lat_deg = 0.01, -0.02
+        x = EARTH_RADIUS_M * math.radians(lon_deg)
+        y = EARTH_RADIUS_M * math.log(
+            math.tan(math.pi / 4 + math.radians(lat_deg) / 2))
+        lon, lat = synthetic_lonlat(x, y)
+        self.assertAlmostEqual(lon, lon_deg, places=12)
+        self.assertAlmostEqual(lat, lat_deg, places=12)
+
+    def test_meter_scale_near_the_anchor(self):
+        # one meter is about 1/111320 degrees at the equator
+        lon, lat = synthetic_lonlat(1.0, 1.0)
+        self.assertAlmostEqual(lon * 111320, 1.0, places=2)
+        self.assertAlmostEqual(lat * 111320, 1.0, places=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit.Dockerfile
+++ b/tests/unit.Dockerfile
@@ -9,8 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv using the installation script
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Add SUMO PPA and install. libatomic1 is a runtime dependency of the
-# libsumo pip wheel, not covered by the apt sumo packages
+# Add SUMO PPA and install
 RUN add-apt-repository ppa:sumo/stable && \
 	apt-get update && apt-get install -y --no-install-recommends \
 	sumo sumo-tools sumo-doc libatomic1

--- a/tests/unit.Dockerfile
+++ b/tests/unit.Dockerfile
@@ -9,10 +9,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install uv using the installation script
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Add SUMO PPA and install
+# Add SUMO PPA and install. libatomic1 is a runtime dependency of the
+# libsumo pip wheel, not covered by the apt sumo packages
 RUN add-apt-repository ppa:sumo/stable && \
 	apt-get update && apt-get install -y --no-install-recommends \
-	sumo sumo-tools sumo-doc
+	sumo sumo-tools sumo-doc libatomic1
 
 # Export SUMO_HOME so traci and libsumo can be found in python
 ENV SUMO_HOME="/usr/share/sumo"


### PR DESCRIPTION
Closes #79.

## Problem

A net without a geo-reference (`projParameter="!"` in its `<location>` element) left the viewer unusable, in two different ways:

- WebSUMO's backend builds the network GeoJSON with sumolib's `convertXY2LonLat()`, which raises `RuntimeError: Network does not provide geo-projection` — the scenario never loads.
- On the OC side, libsumo's `convertGeo()` does **not** fail on such a net: it silently returns the raw x/y meters, so the published positions were meters pretending to be degrees.

## Fix

When the interface detects `projParameter="!"`, it anchors the model at lon/lat 0,0 ("null island"):

- the **served** net file gets a synthetic spherical web mercator projection injected into its `<location>` header, so WebSUMO's own sumolib conversion works unchanged at the current `WEBSUMO_REF` pin, and
- the published vehicle/person positions are converted with the exact inverse of that projection (netOffset removed first, mirroring sumolib).

Spherical web mercator is what MapLibre renders in, so near the anchor the model stays meter-true and undistorted. The anchor is open ocean: the viewer works normally, there is just no map background to toggle on — which is honest for a model that doesn't live anywhere. Geo-referenced nets are served byte-identical and keep using `convertGeo()` exactly as before.

This is deliberately an OC-only fix; the cleaner long-term home (a native no-geo mode in the WebSUMO viewer itself) is recorded in #80.

## Verification

- `synthetic_lonlat()` agrees with sumolib+pyproj on the served file to ~1e-14 degrees.
- End to end with the real stack (nats + websumo + engine): the viewer backend builds the network GeoJSON (previously a `RuntimeError`) and live vehicle positions land on the network geometry. Exercised with `models/test/simple` and with `testmodels/basic/4legleft/4l_50m_` on the integrated engine, signals driven by the phase-ring controller.
- 7 new unit tests (`tests/test_websumo_geo_fallback.py`).

## Also in this PR

The unit test image was missing `libatomic1`, which the libsumo pip wheel needs — every test importing engine code errored out, and this silently hid 18 syvari tests from the suite. With the fix the suite runs 25 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)