### PR TITLE
Move the service images from python 3.9 to 3.13

### DIFF
--- a/services/control_engine/docker/Dockerfile
+++ b/services/control_engine/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/services/indicators/docker/Dockerfile
+++ b/services/indicators/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/services/simengine/docker/Dockerfile
+++ b/services/simengine/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 

--- a/services/simengine/docker/requirements.txt
+++ b/services/simengine/docker/requirements.txt
@@ -2,6 +2,6 @@
 jsmin==3.0.1
 libsumo>=1.27.0
 nats-py==2.9.0; python_version >= '3.7'
-numpy==2.0.2; python_version >= '3.9'
+numpy==2.1.2; python_version >= '3.12'
 shapely==2.0.6; python_version >= '3.7'
 pandas==2.2.3; python_version >= '3.7'

--- a/services/user_interfaces/docker/Dockerfile
+++ b/services/user_interfaces/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Python 3.9 reached end-of-life in October 2025 and no longer receives security fixes. The websumo image already runs 3.13 (bumped in #75's review round); this brings the four remaining service images — simengine, control_engine, user_interfaces, indicators — to the same level, which also matches the pyproject's `requires-python = ">=3.13"`.

## Changes

- `FROM python:3.9-slim` → `FROM python:3.13-slim` in the four service Dockerfiles.
- One pin bump: simengine's `numpy==2.0.2` → `numpy==2.1.2` (2.0.x ships no Python 3.13 wheels, so pip fell back to a meson source build the slim image cannot do; 2.1.2 is the pin control_engine already uses).

Everything else installed unchanged: libsumo 1.27.1, shapely 2.0.6, pandas 2.2.3, nats-py 2.9.0 all have 3.13 wheels.

## Verification

- All four images build.
- The full compose stack runs on the new images: the engine simulates JS270 and publishes to WebSUMO over NATS, the phase-ring controller ticks, the Dash UI serves on 8050, indicators compute queues, and the viewer lists the scenario with the network endpoint returning 200.
- The unit suite already runs on 3.13 (uv-managed per pyproject) independently of these images, so the code side was known-good beforehand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)